### PR TITLE
feat: pause and highlight wish card

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -74,3 +74,17 @@
     @media (max-width: 640px) {
       .wish { min-width: 160px; max-width: 300px; }
     }
+
+    .wish.dimmed { opacity: 0.15; pointer-events: none; }
+    .wish.focused { animation: glow 2s ease-in-out infinite; }
+    .wish .close-btn {
+      position: absolute; top: 6px; right: 6px; width: 24px; height: 24px;
+      border: none; border-radius: 50%; cursor: pointer;
+      background: rgba(0,0,0,0.4); color: #fff; line-height: 24px; font-size: 16px;
+    }
+    .wish .close-btn:hover { background: rgba(0,0,0,0.6); }
+    @keyframes glow {
+      0% { box-shadow: 0 0 0 0 rgba(102,227,255,0.7); }
+      70% { box-shadow: 0 0 0 20px rgba(102,227,255,0); }
+      100% { box-shadow: 0 0 0 0 rgba(102,227,255,0); }
+    }


### PR DESCRIPTION
## Summary
- allow pausing all wish cards and highlight one in the center on click
- dim other cards and add close button to resume movement

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f9a289ec8332972580d98cc6ab94